### PR TITLE
Maybe fix bug for Common.shouldDelay

### DIFF
--- a/src/com/androidquery/util/Common.java
+++ b/src/com/androidquery/util/Common.java
@@ -283,11 +283,9 @@ public class Common implements Comparator<File>, Runnable, OnClickListener, OnIt
 				
 					AbsListView lv = (AbsListView) parent;
 					
-					if(lv.getAdapter() instanceof BaseAdapter){	
-						sl = new Common();
-						lv.setOnScrollListener(sl);
-						lv.setTag(AQuery.TAG_SCROLL_LISTENER, sl);				
-					}
+					sl = new Common();
+					lv.setOnScrollListener(sl);
+					lv.setTag(AQuery.TAG_SCROLL_LISTENER, sl);				
 					
 				}else{
 					state = sl.getScrollState();


### PR DESCRIPTION
This commit is just removing BaseAdapter check code in Common#shouldDelay

If ListView#addFooterView or ListView#addHeaderView are used, ListView#setAdapter use wrapper adapter(aka HeaderViewListAdapter) that implemented just ListAdapter.

Because of this wrapper adapter, BaseAdapter type checking code block Common#shouldDelay's right operation.

I think this code to need double check with you. I don't exactly understand why you check BaseAdapter at that position. I just edit code and check for my application's right operation. 

Thank you for this feature. My original delayed image loading part changed very simple code. 
