### PR TITLE
setting right filename in Content-Disposition part

### DIFF
--- a/src/com/androidquery/callback/AbstractAjaxCallback.java
+++ b/src/com/androidquery/callback/AbstractAjaxCallback.java
@@ -1417,7 +1417,7 @@ public abstract class AbstractAjaxCallback<T, K> implements Runnable{
 		if(obj == null) return;
 		
 		if(obj instanceof File){
-			writeData(dos, name, new FileInputStream((File) obj));
+			writeData(dos, name, (File) obj);
 		}else if(obj instanceof byte[]){
 			writeData(dos, name, new ByteArrayInputStream((byte[]) obj));
 		}else{
@@ -1427,6 +1427,19 @@ public abstract class AbstractAjaxCallback<T, K> implements Runnable{
 	}
 	
 	
+	private static void writeData(DataOutputStream dos, String name, File file) throws IOException {
+		InputStream is = new FileInputStream(file);
+
+		dos.writeBytes(twoHyphens + boundary + lineEnd);
+		dos.writeBytes("Content-Disposition: form-data; name=\""+name+"\";"
+				+ " filename=\"" + file.getName() + "\"" + lineEnd);
+		dos.writeBytes(lineEnd);
+
+		AQUtility.copy(is, dos);
+		
+		dos.writeBytes(lineEnd);
+	}
+
 	private static void writeData(DataOutputStream dos, String name, InputStream is) throws IOException {
 		
 		dos.writeBytes(twoHyphens + boundary + lineEnd);


### PR DESCRIPTION
About :
When I had tried to upload a file, I found that the file name passed is wrong. This patch fixed that problem.

Analysis :
At file uploading, android-query uses writeData method and it is implemented like this :

private static void writeData(DataOutputStream dos, String name, InputStream is) throws IOException {

```
    dos.writeBytes(twoHyphens + boundary + lineEnd);
    dos.writeBytes("Content-Disposition: form-data; name=\""+name+"\";"
            + " filename=\"" + name + "\"" + lineEnd); <------ 'name' means form name, not file name
    dos.writeBytes(lineEnd);

    AQUtility.copy(is, dos);

    dos.writeBytes(lineEnd);
}
```
