### PR TITLE
In Common.showProgress , fix code to match progress visibility code for common View object

### DIFF
--- a/src/com/androidquery/util/Common.java
+++ b/src/com/androidquery/util/Common.java
@@ -514,7 +514,7 @@ public class Common implements Comparator<File>, Runnable, OnClickListener, OnLo
 						if(pbar != null && pbar.isIndeterminate()){
 							pbar.setIndeterminate(false);
 						}
-						pv.setVisibility(View.GONE);						
+						pv.setVisibility(View.GONE);
 					}
 				}
 			}else if(p instanceof Dialog){

--- a/src/com/androidquery/util/Common.java
+++ b/src/com/androidquery/util/Common.java
@@ -512,8 +512,9 @@ public class Common implements Comparator<File>, Runnable, OnClickListener, OnLo
 						pv.setTag(AQuery.TAG_URL, null);	
 						
 						if(pbar != null && pbar.isIndeterminate()){
-							pv.setVisibility(View.GONE);						
+							pbar.setIndeterminate(false);
 						}
+						pv.setVisibility(View.GONE);						
 					}
 				}
 			}else if(p instanceof Dialog){


### PR DESCRIPTION
Hello, Peter
Review this code, please. 

If I show progress status, I use a ViewGroup included progress bar for additional information expression. So, I set common view to 'AQuerion#progress' method. 

Before 2012-08-11, this pattern work well (for example 'q.progress(commonView).image(url)')
But now, if I set common view, this view object just show at start-time and don't hide after job finished.

You also could read this issue from https://groups.google.com/forum/?fromgroups=#!topic/android-query/HQ9JJaNbwBQ

Review please. 
