### PR TITLE
Make AQuery's temp directory customizable.

### DIFF
--- a/src/com/androidquery/util/AQUtility.java
+++ b/src/com/androidquery/util/AQUtility.java
@@ -607,14 +607,28 @@ public class AQUtility {
 		}
 	}
 	
+	private static File tempDir;
+	
 	public static File getTempDir(){
-		File ext = Environment.getExternalStorageDirectory();
-		File tempDir = new File(ext, "aquery/temp");		
-		tempDir.mkdirs();
-		if(!tempDir.exists()){
-		    return null;
+		
+		if(tempDir == null){
+			File ext = Environment.getExternalStorageDirectory();
+			tempDir = new File(ext, "aquery/temp");		
+			tempDir.mkdirs();
+			if(!tempDir.exists()){
+			    return null;
+			}
 		}
+		
 		return tempDir;
+		
+	}
+	
+	public static void setTempDir(File dir){
+		tempDir = dir;
+		if(tempDir != null){
+			tempDir.mkdirs();
+		}
 	}
 	
 	private static boolean testCleanNeeded(File[] files, long triggerSize){


### PR DESCRIPTION
Because AQuery's temp directory (/aquery/temp) exists outside of Android's standard cache directory (/Android/data/[package_name]/), this directory will not be deleted automatically when user uninstalls app.
To solve this, please make AQuery's temp directory customizable.
