### PR TITLE
(Re)add pom.xml to enable Maven release management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ local.properties
 
 proguard-dump.txt
 /assets
+/target

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.googlecode.android-query</groupId>
     <artifactId>android-query</artifactId>
-    <version>0.25.9</version>
+    <version>0.25.10-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>android-query</name>
@@ -28,7 +28,7 @@
         <connection>scm:git:git@github.com:brk3/androidquery.git</connection>
         <developerConnection>scm:git:git@github.com:brk3/androidquery.git</developerConnection>
         <url>git@github.com:brk3/androidquery.git</url>
-      <tag>android-query-0.25.9</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,131 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
+
+    <groupId>com.googlecode.android-query</groupId>
+    <artifactId>android-query</artifactId>
+    <version>0.24.4-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>android-query</name>
+    <description>Android-Query (AQuery) is a light-weight library for doing asynchronous tasks and manipulating UI elements in Android</description>
+    <url>https://code.google.com/p/android-query/</url>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git@github.com:brk3/androidquery.git</connection>
+        <developerConnection>scm:git:git@github.com:brk3/androidquery.git</developerConnection>
+        <url>git@github.com:brk3/androidquery.git</url>
+      <tag>HEAD</tag>
+  </scm>
+
+    <developers>
+        <developer>
+            <id>peter</id>
+            <name>Peter Liu</name>
+            <email>tinyeeliu@gmail.com</email>
+        </developer>
+    </developers>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>android</artifactId>
+            <version>4.1.1.4</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src</sourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>release-sign-artifacts</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.googlecode.android-query</groupId>
     <artifactId>android-query</artifactId>
-    <version>0.24.4-SNAPSHOT</version>
+    <version>0.25.9</version>
     <packaging>jar</packaging>
 
     <name>android-query</name>
@@ -28,7 +28,7 @@
         <connection>scm:git:git@github.com:brk3/androidquery.git</connection>
         <developerConnection>scm:git:git@github.com:brk3/androidquery.git</developerConnection>
         <url>git@github.com:brk3/androidquery.git</url>
-      <tag>HEAD</tag>
+      <tag>android-query-0.25.9</tag>
   </scm>
 
     <developers>


### PR DESCRIPTION
Hi Peter,

Here's the changes to re-add the pom.xml without messing with the src folder structure.  I've also pushed the latest 0.25.9 release to central.
