### PR TITLE
Resume download file

### DIFF
--- a/src/com/androidquery/AbstractAQuery.java
+++ b/src/com/androidquery/AbstractAQuery.java
@@ -2707,5 +2707,43 @@ public abstract class AbstractAQuery<T extends AbstractAQuery<T>> implements Con
 		return download(url, target, cb);
 	
 	}
-	
+
+
+	/**
+	 * Download a file asynchronously.
+	 *
+	 * @param url url
+	 * @param target the file to be saved
+	 * @param resume resume download flag
+	 * @param cb callback to be called when done
+	 * @return self
+	 *
+	 */
+
+	public T download(String url, File target, boolean resume, AjaxCallback<File> cb){
+
+		cb.url(url).type(File.class).targetFile(target).resume(resume);
+		return ajax(cb);
+
+	}
+
+	/**
+	 * Download a file asynchronously.
+	 *
+	 * @param url url
+	 * @param target the file to be saved
+	 * @param resume resume download flag
+	 * @param handler the callback handler
+	 * @param callback the callback method
+	 * @return self
+	 *
+	 */
+
+	public T download(String url, File target, boolean resume, Object handler, String callback){
+
+		AjaxCallback<File> cb = new AjaxCallback<File>();
+		cb.weakHandler(handler, callback);
+		return download(url, target, resume, cb);
+
+	}
 }

--- a/src/com/androidquery/callback/AbstractAjaxCallback.java
+++ b/src/com/androidquery/callback/AbstractAjaxCallback.java
@@ -165,6 +165,7 @@ public abstract class AbstractAjaxCallback<T, K> implements Runnable{
 		transformer = null;
 		ah = null;
 		act = null;
+
 		callback = null;
 		targetFile = null;
 		cacheDir = null;
@@ -173,10 +174,6 @@ public abstract class AbstractAjaxCallback<T, K> implements Runnable{
 		params = null;
 		proxy = null;
 		networkUrl = null;
-		url = null;
-		result = null;
-		type = null;
-		status = null;
 
 		abort = false;
 		blocked = false;
@@ -1213,7 +1210,7 @@ public abstract class AbstractAjaxCallback<T, K> implements Runnable{
 					
 				}else if(status.getFile() != null && status.getSource() == AjaxStatus.NETWORK && status.getInvalid()){
 					File file = status.getFile();
-					if (file != null && file.exists()) {
+					if (file.exists()) {
 						file.delete();
 					}
 				}

--- a/src/com/androidquery/callback/AbstractAjaxCallback.java
+++ b/src/com/androidquery/callback/AbstractAjaxCallback.java
@@ -1584,7 +1584,7 @@ public abstract class AbstractAjaxCallback<T, K> implements Runnable{
 		if(resume && targetFile != null){
 			long len = targetFile.length();
 			if (len > 0){
-				hr.addHeader("Range", "bytes=" + len);
+				hr.addHeader("Range", "bytes=" + len + "-");
 			}
 		}
 		

--- a/src/com/androidquery/callback/AbstractAjaxCallback.java
+++ b/src/com/androidquery/callback/AbstractAjaxCallback.java
@@ -165,6 +165,34 @@ public abstract class AbstractAjaxCallback<T, K> implements Runnable{
 		transformer = null;
 		ah = null;
 		act = null;
+		callback = null;
+		targetFile = null;
+		cacheDir = null;
+		cookies = null;
+		headers = null;
+		params = null;
+		proxy = null;
+		networkUrl = null;
+		url = null;
+		result = null;
+		type = null;
+		status = null;
+
+		abort = false;
+		blocked = false;
+		completed = false;
+		fileCache = false;
+		memCache = false;
+		reauth = false;
+		refresh = false;
+
+		method = Constants.METHOD_DETECT;
+		policy = Constants.CACHE_DEFAULT;
+		lastStatus = 200;
+		expire = 0;
+		retry = 0;
+		timeout = 0;
+		uiCallback = true;
 	}
 	
 	/**
@@ -1183,6 +1211,11 @@ public abstract class AbstractAjaxCallback<T, K> implements Runnable{
 						}
 					}
 					
+				}else if(status.getFile() != null && status.getSource() == AjaxStatus.NETWORK && status.getInvalid()){
+					File file = status.getFile();
+					if (file != null && file.exists()) {
+						file.delete();
+					}
 				}
 			}catch(Exception e){
 				AQUtility.debug(e);
@@ -1663,7 +1696,15 @@ public abstract class AbstractAjaxCallback<T, K> implements Runnable{
 		        		file = null;
 		        	}
 		        }
-	        
+
+	        }catch(IOException e){
+		        if (file != null) {
+			        AQUtility.close(os);
+			        os = null;
+			        file.delete();
+		        }
+		        throw e;
+
 	        }finally{
 	        	AQUtility.close(is);
 	        	AQUtility.close(os);


### PR DESCRIPTION
Add the feature to support resume download file base on my modification of Pull Request #53.

Users can call AQuery.download(String url, File target, boolean resume, Object handler, String callback) continiously to resume downloading a file
