### PR TITLE
400 errors shouldn't prevent normal transformation

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+androidquery

--- a/androidquery.iml
+++ b/androidquery.iml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="LIBRARY_PROJECT" value="true" />
+        <option name="UPDATE_PROPERTY_FILES" value="true" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" generated="true" />
+    </content>
+    <orderEntry type="jdk" jdkName="Android 4.4 Platform" jdkType="Android SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>
+

--- a/project.properties
+++ b/project.properties
@@ -9,4 +9,4 @@
 
 android.library=true
 # Project target.
-target=android-7
+target=android-19

--- a/src/com/androidquery/callback/AbstractAjaxCallback.java
+++ b/src/com/androidquery/callback/AbstractAjaxCallback.java
@@ -1735,7 +1735,7 @@ public abstract class AbstractAjaxCallback<T, K> implements Runnable{
         File file = null;
         File tempFile = null;
         
-        if(code < 200 || code >= 300){     
+        if(code < 200 || code >= 500){
         	
         	InputStream is = null;
         	


### PR DESCRIPTION
This is up to the client to decide.

REST clients pass 4xx errors to inform certain bad requests and you’re supposed to retry those requests after you make some changes (otherwise it will fail again).

In practice, the 4xx error will come with some data too, like some custom response indicating error codes among any other imaginable thing. If you treat 400 as a regular error, then that response is never going to pass through the `transform(url, type, encoding, data, status);` method  in `AbstractAjaxCallback.java`
